### PR TITLE
fix the bug in trap_handler()

### DIFF
--- a/05-Preemptive/sys.s
+++ b/05-Preemptive/sys.s
@@ -141,9 +141,5 @@ trap_vector:
 	# load context(registers).
 	csrr	t6, mscratch
 	reg_load t6
-
-        # jump to sys_kernel
-        la a1, os_kernel # a1 = os_kernel
-        csrw mepc, a1    # mepc = sys_kernel
 	mret
 

--- a/05-Preemptive/trap.c
+++ b/05-Preemptive/trap.c
@@ -26,7 +26,7 @@ reg_t trap_handler(reg_t epc, reg_t cause)
     case 7:
       lib_puts("timer interruption!\n");
       // disable machine-mode timer interrupts.
-      w_mie(r_mie() & 0 << 7);
+      w_mie(~((~r_mie()) | (1 << 7)));
       timer_handler();
       return_pc = (reg_t)&os_kernel;
       // enable machine-mode timer interrupts.

--- a/05-Preemptive/trap.c
+++ b/05-Preemptive/trap.c
@@ -25,7 +25,12 @@ reg_t trap_handler(reg_t epc, reg_t cause)
       break;
     case 7:
       lib_puts("timer interruption!\n");
+      // disable machine-mode timer interrupts.
+      w_mie(r_mie() & 0 << 7);
       timer_handler();
+      return_pc = (reg_t)&os_kernel;
+      // enable machine-mode timer interrupts.
+      w_mie(r_mie() | MIE_MTIE);
       break;
     case 11:
       lib_puts("external interruption!\n");

--- a/05-Preemptive/user.c
+++ b/05-Preemptive/user.c
@@ -3,7 +3,8 @@
 void user_task0(void)
 {
 	lib_puts("Task0: Created!\n");
-	while (1) {
+	while (1)
+	{
 		lib_puts("Task0: Running...\n");
 		lib_delay(1000);
 	}
@@ -12,13 +13,15 @@ void user_task0(void)
 void user_task1(void)
 {
 	lib_puts("Task1: Created!\n");
-	while (1) {
+	while (1)
+	{
 		lib_puts("Task1: Running...\n");
 		lib_delay(1000);
 	}
 }
 
-void user_init() {
+void user_init()
+{
 	task_create(&user_task0);
 	task_create(&user_task1);
 }


### PR DESCRIPTION
Dear @ccckmit ,
這次提交主要修正了兩個問題:
- 之前的 `trap_vector()` 會不分中斷類型的一律將 mepc 指向 `sys_kernel()` ，這樣會衍生出一個問題: 若作業系統支援了軟體中斷或是外部中斷，作業系統一樣會執行排程器中的下一個任務，所以我將設定 mepc 的這個步驟挪到 `trap_handler()` 來做，避免掉這個問題。
- 接著，是為了解決 [Issue #3 ](https://github.com/cccriscv/mini-riscv-os/issues/3) 提到的問題，系統在呼叫 `timer_handler()` 前會關閉時間中斷，等到相關作業完成後再啟用，避免了這個潛在問題。
```c=
reg_t trap_handler(reg_t epc, reg_t cause){
  reg_t return_pc = epc;
  reg_t cause_code = cause & 0xfff;
  if (cause & 0x80000000)
  {
    /* Asynchronous trap - interrupt */ 
   switch (cause_code)    {
    case 3:
      lib_puts("software interruption!\n");
      break;
    case 7: 
     lib_puts("timer interruption!\n");
      // disable machine-mode timer interrupts.
      w_mie(~((~r_mie()) | (1 << 7)));
      timer_handler();
      return_pc = (reg_t)&os_kernel;
      // enable machine-mode timer interrupts.
      w_mie(r_mie() | MIE_MTIE);
      break;
    case 11:
      lib_puts("external interruption!\n");
      break;
    default:
      lib_puts("unknown async exception!\n");
      break;
    }
  }
  else  { 
   /* Synchronous trap - exception */
    lib_puts("Sync exceptions!\n");
    while (1)
    {
      /* code */
    }
  }
  return return_pc;
}
```