### PR TITLE
Update os.c

### DIFF
--- a/02-ContextSwitch/os.c
+++ b/02-ContextSwitch/os.c
@@ -1,7 +1,7 @@
 #include "os.h"
 
 #define STACK_SIZE 1024
-uint8_t task0_stack[STACK_SIZE];
+reg_t task0_stack[STACK_SIZE];
 struct context ctx_os;
 struct context ctx_task;
 


### PR DESCRIPTION
Hey there,
I implemented risc-v in fpga and try to port your mini-os to my fpga.
02_ContextSwitch did not work correctly, because the stackpointer is not word alligned after context switch.
Changing uint8_t to word size (32 bit) solved the problem, because &task0_stack[STACK_SIZE-1] should be the last word of the stack, instead of the last byte of the stack.
Some hardware may ignore the two least significant bits of address when accessing a 32 bit word.
So uint8_t might work also.